### PR TITLE
bugfix/FSelect menu slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.1 (June 30, 2022)
+
+### Fixes
+
+- [a11y] Add alt (aria-label) with the country code to FFlagIcon component
+- [FSelect] Forward FMenu options slots properly
+
 ## 0.2.0 (June 30, 2022)
 
 ### Features

--- a/components/FFlagIcon.vue
+++ b/components/FFlagIcon.vue
@@ -4,6 +4,7 @@
     :markup="flagFiles[currentFlagPath]"
     fill-color="none"
     use-svg-colors
+    :alt="countryCode"
     :height="size"
     :width="size"
   )

--- a/components/form/FSelect.vue
+++ b/components/form/FSelect.vue
@@ -16,6 +16,12 @@ FField.FSelect(
     :selected-option-text-color="selectedOptionTextColor"
     :disable-selection="disableSelection"
   )
+    template(#option-prefix)
+      slot(name="option-prefix")
+
+    template(#option)
+      slot(name="option")
+
     template(#activator="{ toggleMenu }")
       .FSelect__select(
         tabindex="0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fifteen/design-system-vue",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "description": "Vue 3 (Composition API + Typescript) implementation of the Fifteen Design System",
   "repository": {


### PR DESCRIPTION
- fix(FSelect): forward FMenu options slots properly
- fix(FFlagIcon): add alt (aria-label) with the country code
- release: 0.2.1
