### PR TITLE
refactor/rename use field with validation functions

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -5,6 +5,7 @@
 - [FInput] Update story to show `type="number"` in action
 - [FInput] Improve `type="number` for iOS Safari (opens a numeric keyboard)
 - [FDigitsInput] Display input type as number with numeric keyboard, while hiding browser spin box
+- [forms] Rename functions `handleValidation` to `validate`, `handleResetValidation` to `resetValidation`
 
 ### Fixes
 
@@ -12,3 +13,4 @@
 - [FDigitsInput] Fix alignment of input content that was not properly centered
 - [FInput] Allow all the input area to be clickable, as an input should be
 - [Core] Expose `removeDiacritics` util
+- [forms] Remove emits inside custom rules causing events to fire twice

--- a/components/form/FCheckbox.vue
+++ b/components/form/FCheckbox.vue
@@ -266,10 +266,10 @@ const {
   isValid,
   hint,
   value: fieldValue,
-  handleValidation,
+  validate,
 } = useFieldWithValidation(props, { validateOnMount: props.validateOnMount });
 const { handleBlur, handleFocus } = useInputEventBindings(
-  handleValidation,
+  validate,
   props.validationTrigger,
   emit
 );
@@ -320,7 +320,7 @@ const checkboxClasses = computed(() => ({
  * Custom handle change function because native onChange emits a "on" value when true
  */
 function handleChange() {
-  handleValidation(fieldValue.value, props.validationTrigger === 'change');
+  validate(fieldValue.value, props.validationTrigger === 'change');
 }
 
 /**

--- a/components/form/FCreditCardInput.vue
+++ b/components/form/FCreditCardInput.vue
@@ -247,13 +247,13 @@ defineExpose<{
   focus,
 });
 
-const { isValid, hint, value, handleValidation, handleResetValidation } =
+const { isValid, hint, value, validate, resetValidation } =
   useFieldWithValidation<string | number>(props, {
     validateOnMount: props?.validateOnMount,
     rules: [isValidCreditCard],
   });
 const { handleBlur, handleChange, handleFocus, handleInput } =
-  useInputEventBindings(handleValidation, props.validationTrigger, emit);
+  useInputEventBindings(validate, props.validationTrigger, emit);
 
 const classes = computed(() => ({
   'FCreditCardInput--disabled': props.disabled,
@@ -295,10 +295,10 @@ watch(value, newValue => {
     // Manually trigger validation if :
     // - Input value length matches one of the lengths of the matched credit card
     // - No credit card was found but input value length reached the number of digits of default mask
-    handleValidation(newValue);
+    validate(newValue);
   } else {
     // Else trigger field validation reset to remove eventual errors while user is interacting with input
-    handleResetValidation();
+    resetValidation();
   }
 
   creditCard.value = newCreditCard;
@@ -321,7 +321,7 @@ function isValidCreditCard(value: unknown): boolean {
 }
 
 function handleFocusAndResetValidation(e: Event) {
-  handleResetValidation();
+  resetValidation();
   handleFocus(e);
 }
 

--- a/components/form/FCreditCardInput.vue
+++ b/components/form/FCreditCardInput.vue
@@ -303,6 +303,10 @@ watch(value, newValue => {
 
   creditCard.value = newCreditCard;
   emit('credit-card', newCreditCard);
+
+  if (isValidCreditCard(newValue)) {
+    emit('complete');
+  }
 });
 
 /**
@@ -315,8 +319,6 @@ function isValidCreditCard(value: unknown): boolean {
   const valid =
     luhnCheck(spacelessValue) &&
     creditCard.value.lengths.includes(spacelessValue.length);
-
-  if (valid) emit('complete');
   return valid;
 }
 

--- a/components/form/FDigitsInput.vue
+++ b/components/form/FDigitsInput.vue
@@ -214,7 +214,7 @@ const {
   isValid,
   hint,
   value: fieldValue,
-  handleValidation,
+  validate,
 } = useFieldWithValidation(props, {
   validateOnMount: props.validateOnMount,
 });
@@ -235,7 +235,7 @@ watch(digitsValue, () => {
     digitsValue.value.length === props.digits &&
     !digitsValue.value.some(value => value === '')
   ) {
-    handleValidation(digitsValue.value.join(''));
+    validate(digitsValue.value.join(''));
     emit('complete');
   }
 });
@@ -290,7 +290,7 @@ function forceDigitsValidation() {
 watch(isValid, forceDigitsValidation);
 
 function handleDigitChange() {
-  handleValidation(digitsValue.value.join(''));
+  validate(digitsValue.value.join(''));
 }
 
 /**

--- a/components/form/FFileUpload.vue
+++ b/components/form/FFileUpload.vue
@@ -193,13 +193,10 @@ const props = withDefaults(defineProps<FFileUploadProps>(), {
 
 const underlyingFileInputRef = ref<HTMLInputElement>();
 
-const { isValid, hint, value, validate } = useFieldWithValidation(
-  props,
-  {
-    validateOnMount: props?.validateOnMount,
-    rules: [isValidFile],
-  }
-);
+const { isValid, hint, value, validate } = useFieldWithValidation(props, {
+  validateOnMount: props?.validateOnMount,
+  rules: [isValidFile],
+});
 
 const emit = defineEmits<{
   (name: 'update:modelValue', value: File[] | null | undefined): void;
@@ -218,6 +215,12 @@ function isValidFile(value: unknown): boolean {
 
   return isValidFormatAndSize;
 }
+
+watch(value, newValue => {
+  if (!!newValue?.length && isValidFile(newValue)) {
+    emit('files', newValue as File[]);
+  }
+});
 
 const { handleChange } = useInputEventBindings(
   validate,

--- a/components/form/FFileUpload.vue
+++ b/components/form/FFileUpload.vue
@@ -209,9 +209,6 @@ function isValidFile(value: unknown): boolean {
   const isValidSize = sizeRule(value, { size: props.maximumSize });
 
   const isValidFormatAndSize = isValidFormat && isValidSize;
-  if (isValidFormatAndSize) {
-    emit('files', value as File[]);
-  }
 
   return isValidFormatAndSize;
 }

--- a/components/form/FFileUpload.vue
+++ b/components/form/FFileUpload.vue
@@ -61,7 +61,7 @@ FField.FFileUpload(
 </style>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import FButton from '@/components/FButton.vue';
 import FIcon from '@/components/FIcon.vue';
 import FField from '@/components/form/FField.vue';
@@ -193,7 +193,7 @@ const props = withDefaults(defineProps<FFileUploadProps>(), {
 
 const underlyingFileInputRef = ref<HTMLInputElement>();
 
-const { isValid, hint, value, handleValidation } = useFieldWithValidation(
+const { isValid, hint, value, validate } = useFieldWithValidation(
   props,
   {
     validateOnMount: props?.validateOnMount,
@@ -220,7 +220,7 @@ function isValidFile(value: unknown): boolean {
 }
 
 const { handleChange } = useInputEventBindings(
-  handleValidation,
+  validate,
   props.validationTrigger,
   emit
 );

--- a/components/form/FInput.vue
+++ b/components/form/FInput.vue
@@ -288,12 +288,12 @@ defineExpose<{
   focus,
 });
 
-const { isValid, hint, value, handleValidation } = useFieldWithValidation(
+const { isValid, hint, value, validate } = useFieldWithValidation(
   props,
   { validateOnMount: props.validateOnMount }
 );
 const { handleBlur, handleChange, handleInput, handleFocus } =
-  useInputEventBindings(handleValidation, props.validationTrigger, emit);
+  useInputEventBindings(validate, props.validationTrigger, emit);
 
 const style = computed(
   (): Style => ({
@@ -327,7 +327,7 @@ const hintTextColor = computed(() =>
  * Force validation from parent component, eg. in case of rules change
  */
 function forceValidation() {
-  handleValidation(value.value);
+  validate(value.value);
 }
 
 /**

--- a/components/form/FPhoneInput.vue
+++ b/components/form/FPhoneInput.vue
@@ -318,7 +318,7 @@ defineExpose<{
   focus,
 });
 
-const { isValid, hint, handleValidation } = useFieldWithValidation<
+const { isValid, hint, validate } = useFieldWithValidation<
   string | number
 >(props, {
   validateOnMount: props?.validateOnMount,
@@ -326,7 +326,7 @@ const { isValid, hint, handleValidation } = useFieldWithValidation<
 });
 const { handleBlur, handleChange, handleFocus, handleInput } =
   useInputEventBindings(
-    () => handleValidation(fullPhone.value),
+    () => validate(fullPhone.value),
     props.validationTrigger,
     emit
   );
@@ -364,7 +364,7 @@ const fullPhone = computed(() => {
 
 // Handle value update only. Validation is performed with 'validation-trigger' event
 watch([phonePrefix, phoneNumber], () => {
-  handleValidation(fullPhone.value, false);
+  validate(fullPhone.value, false);
 });
 
 const countries = getCountries().map((country: CountryCode) => ({

--- a/components/form/FRadio.vue
+++ b/components/form/FRadio.vue
@@ -248,10 +248,10 @@ const {
   isValid,
   hint,
   value: fieldValue,
-  handleValidation,
+  validate,
 } = useFieldWithValidation(props, { validateOnMount: props.validateOnMount });
 const { handleBlur, handleFocus, handleChange } = useInputEventBindings(
-  handleValidation,
+  validate,
   props.validationTrigger,
   emit
 );

--- a/components/form/FRadioGroup.vue
+++ b/components/form/FRadioGroup.vue
@@ -146,14 +146,14 @@ defineExpose<{
   focus,
 });
 
-const { value, isValid, hint, handleValidation } = useFieldWithValidation(
+const { value, isValid, hint, validate } = useFieldWithValidation(
   props,
   {
     validateOnMount: props.validateOnMount,
   }
 );
 const { handleChange, handleFocus, handleBlur } = useInputEventBindings(
-  handleValidation,
+  validate,
   props.validationTrigger,
   emit
 );

--- a/components/form/FSelect.vue
+++ b/components/form/FSelect.vue
@@ -363,12 +363,12 @@ const {
   isValid,
   hint,
   value: fieldValue,
-  handleValidation,
+  validate,
 } = useFieldWithValidation<string | number>(props, {
   validateOnMount: props?.validateOnMount,
 });
 const { handleFocus, handleChange } = useInputEventBindings(
-  handleValidation,
+  validate,
   props.validationTrigger,
   emit
 );

--- a/components/form/FTextarea.vue
+++ b/components/form/FTextarea.vue
@@ -257,12 +257,12 @@ defineExpose<{
 
 const textareaRef = ref();
 
-const { isValid, hint, value, handleValidation } =
+const { isValid, hint, value, validate } =
   useFieldWithValidation<string>(props, {
     validateOnMount: props.validateOnMount,
   });
 const { handleChange, handleFocus, handleBlur } = useInputEventBindings(
-  handleValidation,
+  validate,
   props.validationTrigger,
   emit
 );

--- a/composables/useFieldWithValidation.ts
+++ b/composables/useFieldWithValidation.ts
@@ -31,14 +31,14 @@ interface UseFieldWithValidationReturns {
   /**
    * Function which handles field update, with validation or not
    */
-  handleValidation: (
+  validate: (
     e: Event | string | number | boolean | null,
     shouldValidate?: boolean
   ) => void;
   /**
    * Function which resets field validation
    */
-  handleResetValidation: () => void;
+  resetValidation: () => void;
   /**
    * Input field ref value
    */
@@ -113,7 +113,7 @@ export function useFieldWithValidation<
     );
 
     return {
-      handleValidation: async (eventOrValue, validateField = true) => {
+      validate: async (eventOrValue, validateField = true) => {
         // Value is only used when validation in manual (eg. for custom inputs like FPhoneInput or FDigitsInput)
         const value =
           eventOrValue instanceof Event ? fieldValue.value : eventOrValue;
@@ -124,7 +124,7 @@ export function useFieldWithValidation<
           isValid.value = result.valid;
         }
       },
-      handleResetValidation: () => {
+      resetValidation: () => {
         errors.value = [];
         isValid.value = true;
       },
@@ -157,8 +157,8 @@ export function useFieldWithValidation<
   const isValid = computed(() => errors.value.length === 0);
 
   return {
-    handleValidation: handleChange,
-    handleResetValidation: () => {
+    validate: handleChange,
+    resetValidation: () => {
       errors.value = [];
     },
     value,


### PR DESCRIPTION
Closes [SVC-5604](https://zoov-eu.atlassian.net/browse/SVC-5604)

- refactor: rename useFieldWithValidation handleValidation,handleResetValidation
- fix: fix events firing twice because inside custom rules
- feat: update changelog unreleased
