### PR TITLE
bugfix/phone model crash autocomplete validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.7.6 (November 23, 2022)
+
+### Fixes
+
+- [FAutocompleteInput] Allow empty input to be a valid state
+- [FPhoneInput] Prevent potential crash on parsing modelValue
+
 ## 0.7.5 (November 22, 2022)
 
 ### Changes

--- a/components/form/FAutocompleteInput.vue
+++ b/components/form/FAutocompleteInput.vue
@@ -354,7 +354,7 @@ function handleInput(e: InputEvent) {
 }
 
 function isValidMatch() {
-  return !!currentOptionMatched.value;
+  return !inputValue.value || !!currentOptionMatched.value;
 }
 
 function handleSelectOption(optionValue: any) {

--- a/components/form/FPhoneInput.vue
+++ b/components/form/FPhoneInput.vue
@@ -155,7 +155,7 @@ import FIcon from '@/components/FIcon.vue';
 import FField from '@/components/form/FField.vue';
 
 import {
-  isValidNumber,
+  isValidPhoneNumber,
   getCountries,
   getCountryCallingCode,
   getExampleNumber,
@@ -413,14 +413,14 @@ function isEmptyPhone(value: unknown): boolean {
 // Internal validation rule, always applied
 function isValidPhone(value: unknown) {
   if (typeof value !== 'string') return false;
-  return isValidNumber(value);
+  return isValidPhoneNumber(value);
 }
 
 watch(
   () => props.modelValue,
   newModelValue => {
     if (!newModelValue) return;
-
+    if (!isValidPhoneNumber(newModelValue)) return;
     const parsedNumber = parsePhoneNumber(newModelValue);
     phoneNumber.value = parsedNumber.nationalNumber;
     if (parsedNumber.country) countryCode.value = parsedNumber.country;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fifteen/design-system-vue",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": false,
   "description": "Vue 3 (Composition API + Typescript) implementation of the Fifteen Design System",
   "repository": {

--- a/stories/FAutocompleteInput.stories.ts
+++ b/stories/FAutocompleteInput.stories.ts
@@ -4,6 +4,7 @@ import FAutocompleteInput, {
 } from '@/components/form/FAutocompleteInput.vue';
 import FButton from '@/components/FButton.vue';
 import { ref } from 'vue';
+import { required } from '@vee-validate/rules';
 
 export default {
   title: 'Components/Form/FAutocompleteInput',
@@ -76,6 +77,7 @@ Error.args = {
   options: capitals,
   label: 'Choose a capital',
   validateOnMount: true,
+  rules: [required],
   errorMessage: 'Choose an option to dismiss the error',
 };
 


### PR DESCRIPTION
- fix: allow autocomplete to be valid if input is empty
- fix: avoid phone input to crash when parsing an external number
- release: 0.7.6
