### PR TITLE
bugfix/select reset and phone input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.22.1 (November 27, 2023)
+
+### Fixes
+
+- [FPhoneInput] Make the FInput carry the label, hint, and validation logic
+- [Typing] Upgrade tsconfig and ensure components link
+- [FForm] Add story to document validation behavior
+- [Icons] Warn about missing icon only if name is not null
+- [FSelect] Remove sync watcher conflicting with form reset
+- [FLocaleSelect] Properly send name to FSelect to ensure from reset
+
 ## 0.22.0 (November 10, 2023)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@typescript-eslint/typescript-estree": "^5.26.0",
     "@vitejs/plugin-vue": "^2.3.3",
     "@volar/vue-language-plugin-pug": "^1.0.3",
+    "@vue/tsconfig": "^0.4.0",
     "babel-loader": "^8.2.5",
     "camelcase": "^6.3.0",
     "csstype": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fifteen/design-system-vue",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Vue 3 (Composition API + Typescript) implementation of the Fifteen Design System",
   "repository": {
     "type": "git",

--- a/src/components/form/FLocaleSelect.vue
+++ b/src/components/form/FLocaleSelect.vue
@@ -152,6 +152,7 @@ const emit = defineEmits<{
 
 const selectProps = {
   label: props.label,
+  name: props.name,
   color: props.color,
   textColor: props.textColor,
   focusColor: props.focusColor,

--- a/src/components/form/FPhoneInput.vue
+++ b/src/components/form/FPhoneInput.vue
@@ -1,8 +1,7 @@
 <template lang="pug">
-FField.FPhoneInput(
+.FPhoneInput(
   :class="classes"
   :style="style"
-  v-bind="{ name, label, labelTextColor, hint, hideHint, hintTextColor, hintIcon }"
 )
   FMenu(
     v-model="isMenuOpen"
@@ -19,6 +18,9 @@ FField.FPhoneInput(
       FInput(
         ref="inputRef"
         v-model="phoneNumber"
+        :name="name"
+        :label="label"
+        :label-text-color="labelTextColor"
         :color="color"
         :text-color="textColor"
         :error-message="errorMessage"
@@ -27,19 +29,21 @@ FField.FPhoneInput(
         :validate-on-mount="validateOnMount"
         :validation-trigger="validationTrigger"
         :disabled="disabled"
-        :rules="[() => isValid]"
+        :rules="resolvedRules"
         :outline-color="outlineColor"
         :focus-color="focusColor"
         :border-color="borderColor"
         :focus-border-color="focusBorderColor"
         :error-color="errorColor"
-        hide-hint
+        :hide-hint="hideHint"
+        :hint="hint"
+        :hint-icon="hintIcon"
         :mask="phoneNumberMask"
         :loading="loading"
-        @focus="handleFocus"
-        @blur="handleBlur"
-        @change="handleChange"
-        @input="handleInput"
+        @focus="emit('focus', $event)"
+        @blur="emit('blur', $event)"
+        @change="emit('change', $event)"
+        @input="emit('input', $event)"
       )
         template(#prefix)
           .FPhoneInput__prefix
@@ -74,6 +78,7 @@ FField.FPhoneInput(
               @click.stop="toggleMenu"
               @blur="closeMenu"
             ) {{ phonePrefix }}
+
     template(#option-prefix="{ option }")
       FFlagIcon.FPhoneInput__optionPrefix(:flag-code="getCountryCode(option)")
 </template>
@@ -81,6 +86,8 @@ FField.FPhoneInput(
 <style lang="stylus">
 .FPhoneInput
   background none
+  display flex
+  flex-direction column
 
 .FPhoneInput__select
   display flex
@@ -171,7 +178,7 @@ import { getCssColor } from '@/utils/getCssColor';
 import type { FFieldProps } from '@/components/form/FField.vue';
 import type { CountryCode } from '@/types/flags';
 import type { FMenuOption } from '@/components/FMenu.vue';
-import type { CommonFormFieldProps } from '@/types/forms';
+import type { ValidationRule, CommonFormFieldProps } from '@/types/forms';
 import type { Color } from '@/types/colors';
 
 export interface FPhoneInputProps
@@ -241,6 +248,7 @@ const props = withDefaults(defineProps<FPhoneInputProps>(), {
 });
 
 const emit = defineEmits<{
+  (name: 'update:countryCode', value: CountryCode): void;
   (name: 'update:phoneNumber', value: string | null): void;
   (name: 'input', value: InputEvent): void;
   (name: 'change', value: Event): void;
@@ -259,24 +267,19 @@ const countryCode = useVModelProxy<CountryCode>({
   propName: 'countryCode',
 });
 
-const {
-  isValid,
-  hint,
-  validate,
-  value: rawValue,
-} = useFieldWithValidation<string | number>(props, {
-  validateOnMount: props?.validateOnMount,
-  rules: [
-    value => isValidPhone(value) || isEmptyPhone(value),
-    ...(Array.isArray(props.rules) ? props.rules : [props.rules]),
-  ],
+const fullPhone = computed(() => {
+  const phoneValue =
+    phoneNumber.value !== '' ? phonePrefix.value + phoneNumber.value : '';
+
+  return !isEmptyPhone(phoneValue) && isValidPhone(phoneValue)
+    ? parsePhoneNumber(phoneValue).number
+    : phoneValue;
 });
-const { handleBlur, handleChange, handleFocus, handleInput } =
-  useInputEventBindings(
-    () => validate(fullPhone.value),
-    props.validationTrigger,
-    emit
-  );
+
+const resolvedRules = computed<ValidationRule[]>(() => [
+  (value: unknown) => isValidPhone(fullPhone.value) || isEmptyPhone(value),
+  ...(Array.isArray(props.rules) ? props.rules : [props.rules]),
+]);
 
 const classes = computed(() => ({
   'FPhoneInput--disabled': props.disabled,
@@ -301,20 +304,6 @@ const phonePrefix = computed(
   () => `+${getCountryCallingCode(countryCode.value)}`
 );
 const phoneNumber = useVModelProxy<string>({ props, propName: 'phoneNumber' });
-
-const fullPhone = computed(() => {
-  const phoneValue =
-    phoneNumber.value !== '' ? phonePrefix.value + phoneNumber.value : '';
-
-  return !isEmptyPhone(phoneValue) && isValidPhone(phoneValue)
-    ? parsePhoneNumber(phoneValue).number
-    : phoneValue;
-});
-
-// Handle value update only. Validation is performed with 'validation-trigger' event
-watch([phonePrefix, phoneNumber], () => {
-  validate(fullPhone.value, false);
-});
 
 const countries = getCountries().map((country: CountryCode) => ({
   label: country,
@@ -356,26 +345,11 @@ function isValidPhone(value: unknown): boolean {
 
 const isMenuOpen = ref(false);
 
-const hintTextColor = computed(() =>
-  props.disabled
-    ? 'neutral--dark-1'
-    : isValid.value
-    ? props.hintTextColor
-    : props.errorColor
-);
-
 function getCountryCode(option: FMenuOption): CountryCode {
   return option.value as CountryCode;
 }
 
 const inputRef = ref<InstanceType<typeof FInput>>();
-/**
- * Force validation to sync FPhoneInput validation status with underlying FInput
- */
-function forceValidation(): void {
-  inputRef.value?.forceValidation();
-}
-watch(isValid, forceValidation);
 
 /**
  * Focus the input
@@ -383,23 +357,4 @@ watch(isValid, forceValidation);
 function focus(): void {
   inputRef.value?.ref?.focus();
 }
-
-watch(
-  rawValue,
-  newValue => {
-    // Handle initial value
-    const value = String(newValue);
-    if (!isValidPhoneNumber(value)) return;
-    const parsedNumber = parsePhoneNumber(value);
-    phoneNumber.value = parsedNumber.nationalNumber;
-    if (parsedNumber.country) countryCode.value = parsedNumber.country;
-
-    // The raw value (from useFieldWithValidation and so vee-validate) is the source of truth.
-    // So if it is different than the local fullPhone value, actually, it means that the form has been reset
-    if (newValue !== fullPhone.value) {
-      phoneNumber.value = '';
-    }
-  },
-  { immediate: true }
-);
 </script>

--- a/src/components/form/FSelect.vue
+++ b/src/components/form/FSelect.vue
@@ -357,8 +357,6 @@ const iconName = computed(() =>
 
 const optionHeight = computed(() => (props.size === 'medium' ? 52 : 44));
 
-watch(fieldValue, newValue => handleChange(newValue));
-
 /**
  * Get the label of the selected option
  * @param value

--- a/src/composables/useIcon.ts
+++ b/src/composables/useIcon.ts
@@ -50,7 +50,7 @@ export function useIcon<C extends IconCollectionName>(
   watch(
     markup,
     value => {
-      if (!value) {
+      if (unref(iconName) && !value) {
         console.warn(
           `[FDS] Markup for icon "${
             unref(iconName) as string

--- a/src/utils/noop.ts
+++ b/src/utils/noop.ts
@@ -2,4 +2,4 @@
  * No operation function
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-export function noop(): void {};
+export function noop(): void {}

--- a/stories/FAutocomplete.stories.ts
+++ b/stories/FAutocomplete.stories.ts
@@ -1,10 +1,10 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 import { required } from '@vee-validate/rules';
 
 import FAutocomplete from '@/components/form/FAutocomplete.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FAutocompleteProps } from '@/components/form/FAutocomplete.vue';
 
 export default {

--- a/stories/FAvatar.stories.ts
+++ b/stories/FAvatar.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FAvatar from '@/components/FAvatar.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FAvatarProps } from '@/components/FAvatar.vue';
 
 export default {

--- a/stories/FBreadcrumbs.stories.ts
+++ b/stories/FBreadcrumbs.stories.ts
@@ -1,8 +1,8 @@
-import { StoryFn } from '@storybook/vue3';
 
 import { colorDesignTokens } from '@/constants/colors';
 import FBreadcrumbs from '@/components/FBreadcrumbs.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FBreadcrumbsProps } from '@/components/FBreadcrumbs.vue';
 
 export default {

--- a/stories/FButton.stories.ts
+++ b/stories/FButton.stories.ts
@@ -1,10 +1,10 @@
-import { StoryFn } from '@storybook/vue3';
 
 import FButton from '@/components/FButton.vue';
 import FIcon from '@/components/FIcon.vue';
 import { colorDesignTokens } from '@/constants/colors';
 import { getIconList } from '@/.generated/utils';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FButtonProps } from '@/components/FButton.vue';
 
 export default {

--- a/stories/FButtonLink.stories.ts
+++ b/stories/FButtonLink.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FButtonLink from '@/components/router/FButtonLink.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FButtonLinkProps } from '@/components/router/FButtonLink.vue';
 
 export default {

--- a/stories/FCard.stories.ts
+++ b/stories/FCard.stories.ts
@@ -1,8 +1,8 @@
-import { StoryFn } from '@storybook/vue3';
 
 import FCard from '@/components/FCard.vue';
 import { colorDesignTokens } from '@/constants/colors';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FCardProps } from '@/components/FCard.vue';
 
 export default {

--- a/stories/FCheckbox.stories.ts
+++ b/stories/FCheckbox.stories.ts
@@ -1,9 +1,9 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 
 import FCheckbox from '@/components/form/FCheckbox.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FCheckboxProps } from '@/components/form/FCheckbox.vue';
 
 export default {
@@ -48,7 +48,7 @@ const LinkTemplate = (args: FCheckboxProps) => ({
   setup: () => ({ args }),
   template: `<FCheckbox v-bind="args">
       <template v-slot:label>
-        I have read and accept <a href="https://fifteen.eu/fr/legal" target="_blank" style="color:var(--color--primary);">terms</a> 
+        I have read and accept <a href="https://fifteen.eu/fr/legal" target="_blank" style="color:var(--color--primary);">terms</a>
         and <a href="https://fifteen.eu/fr/privacy" target="_blank" style="color:var(--color--primary);">privacy policy</a>.
       </template>
   </FCheckbox>`,

--- a/stories/FCreditCardIcon.stories.ts
+++ b/stories/FCreditCardIcon.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FsCreditCardIconsGrid from './components/FsCreditCardIconsGrid.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FsCreditCardIconGridProps } from './components/FsCreditCardIconsGrid.vue';
 
 export default {

--- a/stories/FCreditCardInput.stories.ts
+++ b/stories/FCreditCardInput.stories.ts
@@ -1,9 +1,9 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 
 import FCreditCardInput from '@/components/form/FCreditCardInput.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FCreditCardInputProps } from '@/components/form/FCreditCardInput.vue';
 
 export default {

--- a/stories/FDigitsInput.stories.ts
+++ b/stories/FDigitsInput.stories.ts
@@ -1,9 +1,9 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 
 import FDigitsInput from '@/components/form/FDigitsInput.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FDigitsInputProps } from '@/components/form/FDigitsInput.vue';
 
 export default {

--- a/stories/FDivider.stories.ts
+++ b/stories/FDivider.stories.ts
@@ -1,8 +1,8 @@
-import { StoryFn } from '@storybook/vue3';
 
 import FDivider from '@/components/FDivider.vue';
 import { colorDesignTokens } from '@/constants/colors';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FDividerProps } from '@/components/FDivider.vue';
 
 export default {

--- a/stories/FExpandable.stories.ts
+++ b/stories/FExpandable.stories.ts
@@ -1,8 +1,8 @@
-import { StoryFn } from '@storybook/vue3';
 
 import FExpandable from '@/components/FExpandable.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FExpandableProps } from '@/components/FExpandable.vue';
 
 export default {

--- a/stories/FFileUpload.stories.ts
+++ b/stories/FFileUpload.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FFileUpload from '@/components/form/FFileUpload.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FFileUploadProps } from '@/components/form/FFileUpload.vue';
 
 export default {

--- a/stories/FFlagIcon.stories.ts
+++ b/stories/FFlagIcon.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FsFlagGrid from './components/FsFlagGrid.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FsFlagGridProps } from './components/FsFlagGrid.vue';
 
 export default {

--- a/stories/FForm.stories.ts
+++ b/stories/FForm.stories.ts
@@ -51,3 +51,19 @@ Loading.args = {
     FAutocomplete: 'a',
   },
 };
+
+export const Validation: StoryFn<FsFormProps> = Template.bind({});
+Validation.args = {
+  withValidation: true,
+  initialValues: {
+    FInput: '',
+    FCheckbox: false,
+    FDigitsInput: '',
+    FPhoneInput: '',
+    FRadioGroup: '',
+    FSelect: '',
+    FLocaleSelect: '',
+    FTextarea: '',
+    FAutocomplete: '',
+  },
+};

--- a/stories/FForm.stories.ts
+++ b/stories/FForm.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FsForm from './components/FsForm.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FsFormProps } from './components/FsForm.vue';
 
 export default {

--- a/stories/FGrid.stories.ts
+++ b/stories/FGrid.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FGrid from '@/components/FGrid.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FGridProps } from '@/components/FGrid.vue';
 
 export default {

--- a/stories/FGridItem.stories.ts
+++ b/stories/FGridItem.stories.ts
@@ -1,9 +1,9 @@
-import { StoryFn } from '@storybook/vue3';
 
 import FGrid from '@/components/FGrid.vue';
 import FCard from '@/components/FCard.vue';
 import FGridItem from '@/components/FGridItem.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FGridItemProps } from '@/components/FGridItem.vue';
 
 export default {

--- a/stories/FIcon.stories.ts
+++ b/stories/FIcon.stories.ts
@@ -1,8 +1,8 @@
 import FsIconGrid from '@@/stories/components/FsIconGrid.vue';
-import { StoryFn } from '@storybook/vue3';
 
 import { colorDesignTokens } from '@/constants/colors';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FsIconGridProps } from '@@/stories/components/FsIconGrid.vue';
 
 export default {

--- a/stories/FImage.stories.ts
+++ b/stories/FImage.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FImage from '@/components/FImage.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FImageProps } from '@/components/FImage.vue';
 
 export default {

--- a/stories/FInput.stories.ts
+++ b/stories/FInput.stories.ts
@@ -1,10 +1,10 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 
 import FInput from '@/components/form/FInput.vue';
 import FButton from '@/components/FButton.vue';
 import { mask, required } from '@/rules';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FInputProps } from '@/components/form/FInput.vue';
 
 export default {

--- a/stories/FLink.stories.ts
+++ b/stories/FLink.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FLink from '@/components/FLink.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FLinkProps } from '@/components/FLink.vue';
 
 export default {

--- a/stories/FLoader.stories.ts
+++ b/stories/FLoader.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FLoader from '@/components/FLoader.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FLoaderProps } from '@/components/FLoader.vue';
 
 export default {

--- a/stories/FLocaleSelect.stories.ts
+++ b/stories/FLocaleSelect.stories.ts
@@ -1,10 +1,10 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 
 import FLocaleSelect from '@/components/form/FLocaleSelect.vue';
 import FSelect from '@/components/form/FSelect.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FLocaleSelectProps } from '@/components/form/FLocaleSelect.vue';
 
 export default {

--- a/stories/FLogo.stories.ts
+++ b/stories/FLogo.stories.ts
@@ -1,8 +1,8 @@
-import { StoryFn } from '@storybook/vue3';
 
 import FLogo from '@/components/FLogo.vue';
 import { colorDesignTokens } from '@/constants/colors';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FLogoProps, FLogoVariant } from '@/components/FLogo.vue';
 
 const logoVariants: FLogoVariant[] = [

--- a/stories/FLogoAnimatable.stories.ts
+++ b/stories/FLogoAnimatable.stories.ts
@@ -1,8 +1,8 @@
-import { StoryFn } from '@storybook/vue3';
 
 import FLogoAnimatable from '@/components/FLogoAnimatable.vue';
 import { colorDesignTokens } from '@/constants/colors';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FLogoAnimatableProps } from '@/components/FLogoAnimatable.vue';
 
 export default {

--- a/stories/FMenu.stories.ts
+++ b/stories/FMenu.stories.ts
@@ -1,10 +1,10 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref, watch } from 'vue';
 
 import FMenu from '@/components/FMenu.vue';
 import FButton from '@/components/FButton.vue';
 import FLink from '@/components/FLink.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FMenuProps, FMenuOption } from '@/components/FMenu.vue';
 
 export default {

--- a/stories/FPhoneInput.stories.ts
+++ b/stories/FPhoneInput.stories.ts
@@ -1,10 +1,10 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 import { required } from '@vee-validate/rules';
 
 import FPhoneInput from '@/components/form/FPhoneInput.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FPhoneInputProps } from '@/components/form/FPhoneInput.vue';
 
 export default {

--- a/stories/FProgressBar.stories.ts
+++ b/stories/FProgressBar.stories.ts
@@ -1,8 +1,8 @@
-import { StoryFn } from '@storybook/vue3';
 
 import { colorDesignTokens } from '@/constants/colors';
 import FProgressBar from '@/components/FProgressBar.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FProgressBarProps } from '@/components/FProgressBar.vue';
 
 export default {

--- a/stories/FRadio.stories.ts
+++ b/stories/FRadio.stories.ts
@@ -1,9 +1,9 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 
 import FRadio from '@/components/form/FRadio.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FRadioProps } from '@/components/form/FRadio.vue';
 import type { FCheckboxProps } from '@/components/form/FCheckbox.vue';
 
@@ -46,12 +46,12 @@ const LinkTemplate = (args: FRadioProps) => ({
   template: `
   <FRadio v-bind="args">
     <template v-slot:label>
-      Fifteen <a href="https://fifteen.eu/fr/smart-station" target="_blank" style="color:var(--color--primary);">smart station</a> 
+      Fifteen <a href="https://fifteen.eu/fr/smart-station" target="_blank" style="color:var(--color--primary);">smart station</a>
     </template>
   </FRadio>
   <FRadio v-bind="args">
     <template v-slot:label>
-      Fifteen <a href="https://fifteen.eu/fr/electric-bike" target="_blank" style="color:var(--color--primary);">electric bikes</a> 
+      Fifteen <a href="https://fifteen.eu/fr/electric-bike" target="_blank" style="color:var(--color--primary);">electric bikes</a>
     </template>
   </FRadio>`,
 });

--- a/stories/FRadioGroup.stories.ts
+++ b/stories/FRadioGroup.stories.ts
@@ -1,9 +1,9 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 
 import FRadioGroup from '@/components/form/FRadioGroup.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FRadioGroupProps } from '@/components/form/FRadioGroup.vue';
 
 export default {

--- a/stories/FRouterLink.stories.ts
+++ b/stories/FRouterLink.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FRouterLink from '@/components/router/FRouterLink.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FRouterLinkProps } from '@/components/router/FRouterLink.vue';
 
 export default {

--- a/stories/FSelect.stories.ts
+++ b/stories/FSelect.stories.ts
@@ -1,10 +1,10 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 
 import FSelect from '@/components/form/FSelect.vue';
 import FIcon from '@/components/FIcon.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FSelectProps } from '@/components/form/FSelect.vue';
 
 export default {

--- a/stories/FSkeleton.stories.ts
+++ b/stories/FSkeleton.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FSkeleton from '@/components/FSkeleton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FSkeletonProps } from '@/components/FSkeleton.vue';
 
 export default {

--- a/stories/FSvgImage.stories.ts
+++ b/stories/FSvgImage.stories.ts
@@ -1,10 +1,10 @@
-import { StoryFn } from '@storybook/vue3';
 import ponyLogoComponent from '@@/stories/assets/pony.svg?component';
 import ponyLogoMarkup from '@@/stories/assets/pony.svg?raw';
 
 import { colorDesignTokens } from '@/constants/colors';
 import FSvgImage from '@/components/FSvgImage.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FSvgImageProps } from '@/components/FSvgImage.vue';
 
 export default {

--- a/stories/FTextContent.stories.ts
+++ b/stories/FTextContent.stories.ts
@@ -1,7 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
-
 import FTextContent from '@/components/FTextContent.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FTextContentProps } from '@/components/FTextContent.vue';
 
 export default {

--- a/stories/FTextarea.stories.ts
+++ b/stories/FTextarea.stories.ts
@@ -1,9 +1,9 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 
 import FTextarea from '@/components/form/FTextarea.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FTextareaProps } from '@/components/form/FTextarea.vue';
 
 export default {

--- a/stories/FToggle.stories.ts
+++ b/stories/FToggle.stories.ts
@@ -1,9 +1,9 @@
-import { StoryFn } from '@storybook/vue3';
 import { ref } from 'vue';
 
 import FToggle from '@/components/form/FToggle.vue';
 import FButton from '@/components/FButton.vue';
 
+import type { StoryFn } from '@storybook/vue3';
 import type { FToggleProps } from '@/components/form/FToggle.vue';
 
 export default {
@@ -39,7 +39,7 @@ const LinkTemplate = (args: FToggleProps) => ({
   setup: () => ({ args }),
   template: `<FToggle v-bind="args">
       <template v-slot:label>
-        I have read and accept <a href="https://fifteen.eu/fr/legal" target="_blank" style="color:var(--color--primary);">terms</a> 
+        I have read and accept <a href="https://fifteen.eu/fr/legal" target="_blank" style="color:var(--color--primary);">terms</a>
         and <a href="https://fifteen.eu/fr/privacy" target="_blank" style="color:var(--color--primary);">privacy policy</a>.
       </template>
   </FToggle>`,

--- a/stories/StylesColors.stories.ts
+++ b/stories/StylesColors.stories.ts
@@ -1,6 +1,7 @@
-import { StoryFn } from '@storybook/vue3';
 import FsColorsCssVars from '@@/stories/components/FsColorsCssVars.vue';
 import FsColorsMixins from '@@/stories/components/FsColorsMixins.vue';
+
+import type { StoryFn } from '@storybook/vue3';
 
 export default {
   title: 'Styles/Colors',

--- a/stories/StylesElevations.stories.ts
+++ b/stories/StylesElevations.stories.ts
@@ -1,5 +1,6 @@
-import { StoryFn } from '@storybook/vue3';
 import FsElevationsMixins from '@@/stories/components/FsElevationsMixins.vue';
+
+import type { StoryFn } from '@storybook/vue3';
 
 export default {
   title: 'Styles/Elevations',

--- a/stories/StylesFonts.stories.ts
+++ b/stories/StylesFonts.stories.ts
@@ -1,6 +1,7 @@
-import { StoryFn } from '@storybook/vue3';
 import FsFontsElements from '@@/stories/components/FsFontsElements.vue';
 import FsFontsMixins from '@@/stories/components/FsFontsMixins.vue';
+
+import type { StoryFn } from '@storybook/vue3';
 
 export default {
   title: 'Styles/Fonts',

--- a/stories/components/FsFontsElements.vue
+++ b/stories/components/FsFontsElements.vue
@@ -16,6 +16,7 @@
     ul: li List item
     code li
   .FsFontsElements__element
+    // eslint-disable-next-line vuejs-accessibility/label-has-for
     label Label
     code label
   .FsFontsElements__element

--- a/stories/components/FsForm.vue
+++ b/stories/components/FsForm.vue
@@ -16,6 +16,7 @@ FForm.FsForm(
         name="FDigitsInput"
         hint="Hint for FDigitsInput"
         :loading="loading"
+        :rules="rules"
       )
     FGridItem(span="12")
       FInput(
@@ -23,6 +24,7 @@ FForm.FsForm(
         name="FInput"
         hint="Hint for FInput"
         :loading="loading"
+        :rules="rules"
       )
     FGridItem(span="12")
       FPhoneInput(
@@ -30,6 +32,7 @@ FForm.FsForm(
         name="FPhoneInput"
         hint="Hint for FPhoneInput"
         :loading="loading"
+        :rules="rules"
       )
     FGridItem(span="12")
       FCreditCardInput(
@@ -37,6 +40,7 @@ FForm.FsForm(
         name="FCreditCardInput"
         hint="Hint for FCreditCardInput"
         :loading="loading"
+        :rules="rules"
       )
     FGridItem(span="12")
       FRadioGroup(
@@ -44,6 +48,7 @@ FForm.FsForm(
         name="FRadioGroup"
         hint="Hint for FRadioGroup"
         :options="radioGroupOptions"
+        :rules="rules"
       )
     FGridItem(span="12")
       FSelect(
@@ -52,6 +57,7 @@ FForm.FsForm(
         hint="Hint for FSelect"
         :options="selectOptions"
         :loading="loading"
+        :rules="rules"
       )
     FGridItem(span="12")
       FLocaleSelect(
@@ -60,6 +66,7 @@ FForm.FsForm(
         hint="Hint for FLocaleSelect"
         :locales="['US', 'FR']"
         :loading="loading"
+        :rules="rules"
       )
     FGridItem(span="12")
       FTextarea(
@@ -67,6 +74,7 @@ FForm.FsForm(
         name="FTextarea"
         hint="Hint for FTextarea"
         :loading="loading"
+        :rules="rules"
       )
     FGridItem(span="12")
       FAutocomplete(
@@ -75,6 +83,7 @@ FForm.FsForm(
         hint="Hint for FAutocomplete"
         :options="autocompleteOptions"
         :loading="loading"
+        :rules="rules"
       )
     FGridItem(span="12")
       FToggle(
@@ -82,7 +91,8 @@ FForm.FsForm(
         name="FToggle"
         hint="Hint for FToggle"
         :loading="loading"
-      ) 
+        :rules="rules"
+      )
     FGridItem.FsForm__actions(span="12")
       FButton(
         :loading="loading"
@@ -101,6 +111,8 @@ FForm.FsForm(
 </style>
 
 <script setup lang="ts">
+import { required } from '@vee-validate/rules';
+
 import type { FFormProps } from '../../src/components/form/FForm.vue';
 
 export interface FsFormProps {
@@ -112,9 +124,13 @@ export interface FsFormProps {
    * Loading state of the form items
    */
   loading?: boolean;
+  /**
+   * With validation
+   */
+  withValidation?: boolean;
 }
 
-defineProps<FsFormProps>();
+const props = defineProps<FsFormProps>();
 
 const radioGroupOptions = [
   { label: 'Option A', value: 'a' },
@@ -133,4 +149,6 @@ const autocompleteOptions = [
   { label: 'Option B', value: 'b' },
   { label: 'Option C', value: 'c' },
 ];
+
+const rules = computed(() => props.withValidation ? [required] : []);
 </script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
   "compilerOptions": {
+    "composite": true,
     "target": "esnext",
     "useDefineForClassFields": true,
     "module": "esnext",
@@ -19,7 +21,8 @@
       "react": ["./stubs/types__react"]
     },
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "types": ["./components.d.ts", "./auto-imports.d.ts"],
   },
   "vueCompilerOptions": {
     "plugins": ["@volar/vue-language-plugin-pug"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2381,6 +2381,7 @@ __metadata:
     "@vee-validate/rules": ^4.10.5
     "@vitejs/plugin-vue": ^2.3.3
     "@volar/vue-language-plugin-pug": ^1.0.3
+    "@vue/tsconfig": ^0.4.0
     "@vueuse/core": ^10.2.1
     babel-loader: ^8.2.5
     camelcase: ^6.3.0
@@ -5344,6 +5345,13 @@ __metadata:
   version: 3.3.4
   resolution: "@vue/shared@npm:3.3.4"
   checksum: 12fe53ff816bfa29ea53f89212067a86512c626b8d30149ff28b36705820f6150e1fb4e4e46897ad9eddb1d1cfc02d8941053939910eed69a905f7a5509baabe
+  languageName: node
+  linkType: hard
+
+"@vue/tsconfig@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@vue/tsconfig@npm:0.4.0"
+  checksum: 1acdd0c5702e163c071fec7ba4ad7eede0a37aaf473e4afc015dad2dd200f85c638831394ca9b9c058cf9d133f4cf92f8d1c99a401f173d5bf1e40700fdcd678
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- fix(FLocaleSelect): properly send name to FSelect to ensure from reset
- fix(FSelect): remove sync watcher conflicting with form reset
- fix(icons): warn only if name is not null
- fix(lint): remove extra semi-colon
- fix(eslint): exception for label in that case
- feat(FForm): add story to document validation behavior
- fix(eslint): use "type" import
- chore(ts): upgrade tsconfig and ensure components link
- fix(FPhoneInput): make the FInput carry the label, hint, and validation logic
- chore: release 0.22.1
